### PR TITLE
Fix build with kernel 4.11

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -46,6 +46,9 @@
 #endif
 	#include <linux/sem.h>
 	#include <linux/sched.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+	#include <linux/sched/signal.h>
+#endif
 	#include <linux/etherdevice.h>
 	#include <linux/wireless.h>
 	#include <net/iw_handler.h>


### PR DESCRIPTION
Linux 4.11 moves signal function declarations to its own header file:
Linux: 3f07c0144132e4f59d88055ac8ff3e691a5fa2b8
("sched/headers: Prepare to move signal wakeup & sigpending methods
from <linux/sched.h> into <linux/sched/signal.h>")

Use new header file "linux/sched/signal.h" to fix build error.

Signed-off-by: Sebastian 'Swift Geek' Grzywna