### PR TITLE
Fix build against kernel 4.11

### DIFF
--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -26,7 +26,9 @@
 
 #ifndef __DRV_TYPES_H__
 #define __DRV_TYPES_H__
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#include <linux/sched/signal.h>
+#endif
 #include <drv_conf.h>
 #include <basic_types.h>
 #include <osdep_service.h>


### PR DESCRIPTION
Simple fix for building against kernel 4.11.0, tested with OrangePi 2 + Armbian dev 5.27