### PR TITLE
Including <linux/version.h> if required

### DIFF
--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -26,6 +26,9 @@
 
 #ifndef __DRV_TYPES_H__
 #define __DRV_TYPES_H__
+#ifndef LINUX_VERSION_CODE
+#include <linux/version.h>
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include <linux/sched/signal.h>
 #endif


### PR DESCRIPTION
I tried building this module as [written on the linux-sinxi.org wiki](http://linux-sunxi.org/Wifi#RTL8189ES_.2F_RTL8189ETV). It didn't compile, the linux version-dependent include added in commit 17ed4c21d9f21b30fd763fab10cebef16a213e41 didn't work without including `linux/version.h`. I added this, it compiled.