### PR TITLE
Fix build with kernel 4.11.9

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3958,7 +3958,12 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
 	strncpy(mon_ndev->name, name, IFNAMSIZ);
 	mon_ndev->name[IFNAMSIZ - 1] = 0;
-	mon_ndev->destructor = rtw_ndev_destructor;
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,11,9))
+ 	mon_ndev->destructor = rtw_ndev_destructor;
+#else
+	mon_ndev->needs_free_netdev = true;
+	mon_ndev->priv_destructor = rtw_ndev_destructor;
+#endif
 	
 #if (LINUX_VERSION_CODE>=KERNEL_VERSION(2,6,29))
 	mon_ndev->netdev_ops = &rtw_cfg80211_monitor_if_ops;

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -3086,7 +3086,6 @@ void rtw_ndev_destructor(struct net_device *ndev)
 	if (ndev->ieee80211_ptr)
 		rtw_mfree((u8 *)ndev->ieee80211_ptr, sizeof(struct wireless_dev));
 #endif
-	free_netdev(ndev);
 }
 
 #ifdef CONFIG_ARP_KEEP_ALIVE


### PR DESCRIPTION
Due to [this commit](https://github.com/torvalds/linux/commit/cf124db566e6b036b8bcbe8decbed740bdfac8c6) which according to [this](https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.11.9) was merged in 4.11.9, the compilation of this module fails without the patch.
This is based on [maurossi/linux@f36cd3](https://github.com/maurossi/linux/commit/f36cd3eb3d3a4e68ef74c9b5fe81cf6469df8adc)