### PR TITLE
Fix build with kernel 4.11.9+

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3958,7 +3958,12 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
 	strncpy(mon_ndev->name, name, IFNAMSIZ);
 	mon_ndev->name[IFNAMSIZ - 1] = 0;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 9))
+	mon_ndev->priv_destructor = rtw_ndev_destructor;
+	mon_ndev->needs_free_netdev = true;
+#else
 	mon_ndev->destructor = rtw_ndev_destructor;
+#endif
 	
 #if (LINUX_VERSION_CODE>=KERNEL_VERSION(2,6,29))
 	mon_ndev->netdev_ops = &rtw_cfg80211_monitor_if_ops;

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -3086,7 +3086,9 @@ void rtw_ndev_destructor(struct net_device *ndev)
 	if (ndev->ieee80211_ptr)
 		rtw_mfree((u8 *)ndev->ieee80211_ptr, sizeof(struct wireless_dev));
 #endif
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 9))
 	free_netdev(ndev);
+#endif
 }
 
 #ifdef CONFIG_ARP_KEEP_ALIVE


### PR DESCRIPTION
A change in struct net_device is introduced in Linux kernel stable
version 4.11.9 and the stable version of 4.12, see upstream Linux commit
cf124db566e6.

It's not introduced in early rc versions of 4.12. so not get fixed by
commit 7402332c0215 ("Fix build with kernel 4.12").

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>