### PR TITLE
Integrate with Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,93 @@
+language: c
+compiler: gcc
+sudo: required
+
+before_install:
+  - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
+  - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
+  - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)
+  - wget ${KERNEL_URL}v${KVER}/$ALL_DEB
+  - sudo dpkg -i *.deb
+
+script:
+  - make CC=$COMPILER KVER=$KVER_BUILD-generic CONFIG_PLATFORM_I386_PC=y
+
+env:
+  global:
+    - KERNEL_URL=http://kernel.ubuntu.com/~kernel-ppa/mainline/
+
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5 KVER=4.14.2
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+      env: COMPILER=gcc-6 KVER=4.14.2
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+      env: COMPILER=gcc-7 KVER=4.14.2
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5 KVER=4.13.16
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5 KVER=4.9.65
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5 KVER=4.6.7
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5 KVER=4.4.102
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+      env: COMPILER=gcc-4.9 KVER=3.16.50
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5 KVER=3.14.79


### PR DESCRIPTION
Hi

This PR add integration with Travis CI in order to compile the code over several combinations of kernel and gcc versions, for ARCH=x86_64, after each commit or PR.

The status of the current build is [there](https://travis-ci.org/CGarces/rtl8189ES_linux/builds/307518005)

Currently the code has several problems, from old kernels like 3.10 to newer ones like 4.14, all of them are already fixed on one of my repositories.

My plan is to send several PR to fix this compilation problems and update the kernel to the last ones from realtek (v4.3.24.8_22657.20170607), using this first PR to show the progress.

To use this PR

Activate Travis CI at the marketplace
Enable the repository in the Travis CI configuration.
Accept this PR.