### PR TITLE
Fix kernel compilation errors

### DIFF
--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4515,7 +4515,11 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t* ssid,
 	source = rtw_zmalloc(2048);
 
 	if (source != NULL) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+		len = kernel_read(fp, source, len, &pos);
+#else
 		len = vfs_read(fp, source, len, &pos);
+#endif
 		rtw_parse_cipher_list(nlo_info, source);
 		rtw_mfree(source, 2048);
 	}

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -46,6 +46,10 @@
 #endif
 	#include <linux/sem.h>
 	#include <linux/sched.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+	#include <linux/sched/signal.h>
+#endif
+	
 	#include <linux/etherdevice.h>
 	#include <linux/wireless.h>
 	#include <net/iw_handler.h>

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -13823,7 +13823,11 @@ static int rtw_ioctl_standard_wext_private(struct net_device *dev, struct ifreq 
 static int rtw_ioctl_wext_private(struct net_device *dev, struct ifreq *rq)
 {
 #ifdef CONFIG_COMPAT
+#ifdef in_compat_syscall
+	if(in_compat_syscall())
+#else
 	if(is_compat_task())
+#endif
 		return rtw_ioctl_compat_wext_private( dev, rq );
 	else
 #endif // CONFIG_COMPAT

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -592,7 +592,11 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 			goto exit;
 	}
 #ifdef CONFIG_COMPAT
+#ifdef in_compat_syscall
+	if (in_compat_syscall()) {
+#else
 	if (is_compat_task()) {
+#endif
 		/* User space is 32-bit, use compat ioctl */
 		compat_android_wifi_priv_cmd compat_priv_cmd;
 


### PR DESCRIPTION
This PR fix several compilation issues as seen on #8 
- Add support for kernel 4.14
- Fix regression bug for kernel 4.11
- Fix compilation issue for kernel >=4.6 on x86

Now [compilation logs](https://travis-ci.org/CGarces/rtl8189ES_linux/builds/308135114) looks fine.

Ping @Icenowy for feedback

