### PR TITLE
Fix Linux build for timer API changes in v4.14

### DIFF
--- a/hal/phydm/phydm_interface.c
+++ b/hal/phydm/phydm_interface.c
@@ -552,7 +552,11 @@ ODM_SetTimer(
 	)
 {
 #if (DM_ODM_SUPPORT_TYPE & ODM_AP)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+	mod_timer(&pTimer->_timer, jiffies + RTL_MILISECONDS_TO_JIFFIES(msDelay));
+#else
 	mod_timer(pTimer, jiffies + RTL_MILISECONDS_TO_JIFFIES(msDelay));
+#endif
 #elif(DM_ODM_SUPPORT_TYPE & ODM_CE)
 	_set_timer(pTimer,msDelay ); //ms
 #elif(DM_ODM_SUPPORT_TYPE & ODM_WIN)
@@ -575,7 +579,11 @@ ODM_InitializeTimer(
 	init_timer(pTimer);
 	pTimer->function = CallBackFunc;
 	pTimer->data = (unsigned long)pDM_Odm;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+	mod_timer(&pTimer->_timer, jiffies+RTL_MILISECONDS_TO_JIFFIES(10));	
+#else
 	mod_timer(pTimer, jiffies+RTL_MILISECONDS_TO_JIFFIES(10));	
+#endif
 #elif(DM_ODM_SUPPORT_TYPE & ODM_CE)
 	PADAPTER Adapter = pDM_Odm->Adapter;
 	_init_timer(pTimer,Adapter->pnetdev,CallBackFunc,pDM_Odm);
@@ -593,7 +601,11 @@ ODM_CancelTimer(
 	)
 {
 #if (DM_ODM_SUPPORT_TYPE & ODM_AP)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+	del_timer(&pTimer->_timer);
+#else
 	del_timer(pTimer);
+#endif
 #elif (DM_ODM_SUPPORT_TYPE & ODM_CE)
 	_cancel_timer_ex(pTimer);
 #elif (DM_ODM_SUPPORT_TYPE & ODM_WIN)

--- a/hal/phydm/phydm_types.h
+++ b/hal/phydm/phydm_types.h
@@ -152,7 +152,12 @@ typedef enum _RT_SPINLOCK_TYPE{
 
 	typedef struct rtl8192cd_priv	*prtl8192cd_priv;
 	typedef struct stat_info		STA_INFO_T,*PSTA_INFO_T;
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+	typedef struct __timer_list		RT_TIMER, *PRT_TIMER;
+#else
 	typedef struct timer_list		RT_TIMER, *PRT_TIMER;
+#endif
 	typedef  void *				RT_TIMER_CALL_BACK;
 
 #ifdef CONFIG_PCI_HCI
@@ -221,8 +226,11 @@ typedef enum _RT_SPINLOCK_TYPE{
 	#elif defined (CONFIG_BIG_ENDIAN)
 		#define	ODM_ENDIAN_TYPE			ODM_ENDIAN_BIG
 	#endif
-	
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+	typedef struct __timer_list		RT_TIMER, *PRT_TIMER;
+#else
 	typedef struct timer_list		RT_TIMER, *PRT_TIMER;
+#endif
 	typedef  void *				RT_TIMER_CALL_BACK;
 	#define	STA_INFO_T			struct sta_info
 	#define	PSTA_INFO_T		struct sta_info *

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -321,7 +321,11 @@ extern void rtw_init_timer(_timer *ptimer, void *padapter, void *pfunc);
 __inline static unsigned char _cancel_timer_ex(_timer *ptimer)
 {
 #ifdef PLATFORM_LINUX
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+	return del_timer_sync(&ptimer->_timer);
+#else
 	return del_timer_sync(ptimer);
+#endif
 #endif
 #ifdef PLATFORM_FREEBSD
 	_cancel_timer(ptimer,0);


### PR DESCRIPTION
Update rtl8189fs branch according to the changes in Linux timer API since v4.14.

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>