### PR TITLE
Feature/kernel 4 19 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get install --only-upgrade dpkg
+  - sudo apt-get install -y dpkg  # to upgrade to dpkg >= 1.17.5ubuntu5.8, which fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
   - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
   - sudo dpkg -i libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
   - rm libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
@@ -16,11 +16,9 @@ before_install:
 
 script:
   - make CC=$COMPILER KVER=$KVER_BUILD-generic CONFIG_PLATFORM_I386_PC=y
-
 env:
   global:
     - KERNEL_URL=http://kernel.ubuntu.com/~kernel-ppa/mainline/
-
 
 matrix:
   include:
@@ -31,6 +29,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-5
+            - libelf-dev
       env: COMPILER=gcc-5 KVER=4.19-rc1
     - compiler: gcc
       addons:
@@ -39,6 +38,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-6
+            - libelf-dev
       env: COMPILER=gcc-6 KVER=4.19-rc1
     - compiler: gcc
       addons:
@@ -47,6 +47,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-7
+            - libelf-dev
       env: COMPILER=gcc-7 KVER=4.19-rc1
     - compiler: gcc
       addons:
@@ -55,23 +56,8 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-5
-      env: COMPILER=gcc-5 KVER=4.15.18
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-6
-      env: COMPILER=gcc-6 KVER=4.15.18
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-7
-      env: COMPILER=gcc-7 KVER=4.15.18
+            - libelf-dev
+      env: COMPILER=gcc-5 KVER=4.14.67
     - compiler: gcc
       addons:
         apt:
@@ -79,68 +65,4 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-5
-      env: COMPILER=gcc-5 KVER=4.14.2
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-6
-      env: COMPILER=gcc-6 KVER=4.14.2
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-7
-      env: COMPILER=gcc-7 KVER=4.14.2
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-5
-      env: COMPILER=gcc-5 KVER=4.13.16
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-5
-      env: COMPILER=gcc-5 KVER=4.9.65
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-5
-      env: COMPILER=gcc-5 KVER=4.6.7
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-5
-      env: COMPILER=gcc-5 KVER=4.4.102
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-4.9
-      env: COMPILER=gcc-4.9 KVER=3.14.79
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-5
-      env: COMPILER=gcc-5 KVER=3.10.108
+      env: COMPILER=gcc-5 KVER=3.14.79

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: required
 before_install:
   - sudo apt-get update
   - sudo apt-get install --only-upgrade dpkg
+  - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
+  - sudo dpkg -i libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
+  - rm libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
   - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
   - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
   - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-5
-      env: COMPILER=gcc-5 KVER=4.19.0
+      env: COMPILER=gcc-5 KVER=4.19-rc1
     - compiler: gcc
       addons:
         apt:
@@ -34,7 +34,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-6
-      env: COMPILER=gcc-6 KVER=4.19.0
+      env: COMPILER=gcc-6 KVER=4.19-rc1
     - compiler: gcc
       addons:
         apt:
@@ -42,7 +42,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-7
-      env: COMPILER=gcc-7 KVER=4.19.0
+      env: COMPILER=gcc-7 KVER=4.19-rc1
     - compiler: gcc
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ compiler: gcc
 sudo: required
 
 before_install:
-  - apt-get update
-  - apt-get upgrade dpkg
+  - sudo apt-get update
+  - sudo apt-get install --only-upgrade dpkg
   - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
   - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
   - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,30 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-5
+      env: COMPILER=gcc-5 KVER=4.19.0
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+      env: COMPILER=gcc-6 KVER=4.19.0
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+      env: COMPILER=gcc-7 KVER=4.19.0
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
       env: COMPILER=gcc-5 KVER=4.15.18
     - compiler: gcc
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ compiler: gcc
 sudo: required
 
 before_install:
+  - apt-get update
+  - apt-get upgrade dpkg
   - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
   - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
   - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)

--- a/include/wifi.h
+++ b/include/wifi.h
@@ -1006,8 +1006,9 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
  */
 #define IEEE80211_MIN_AMPDU_BUF 0x8
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
 #define IEEE80211_MAX_AMPDU_BUF 0x40
-
+#endif
 
 /* Spatial Multiplexing Power Save Modes */
 #define WLAN_HT_CAP_SM_PS_STATIC		0

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -898,7 +898,11 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
  
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) 	
-				, void *accel_priv
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+				, struct net_device *sb_dev
+#else
+                                , void *accel_priv
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) 
 				, select_queue_fallback_t fallback
 #endif


### PR DESCRIPTION
Updates the source code to be able to compile it with kernel 4.19-rc1. The change was needed because of
```
    net: allow ndo_select_queue to pass netdev
    
    This patch makes it so that instead of passing a void pointer as the
    accel_priv we instead pass a net_device pointer as sb_dev. Making this
    change allows us to pass the subordinate device through to the fallback
    function eventually so that we can keep the actual code in the
    ndo_select_queue call as focused on possible on the exception cases.
```

I also changed the Travis file to be sure it will compile for 4.19 too. I had to do some weird workarounds to install the newer kernel on Ubuntu 14.04 (the build system that Travis uses) like upgrade dpkg and install libssl. Build results here:
https://travis-ci.org/jerbob92/rtl8189fs_linux/builds/423567823