### PR TITLE
Feature/kernel 4 19 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,68 @@
+language: c
+compiler: gcc
+sudo: required
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y dpkg  # to upgrade to dpkg >= 1.17.5ubuntu5.8, which fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
+  - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
+  - sudo dpkg -i libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
+  - rm libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
+  - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
+  - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
+  - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)
+  - wget ${KERNEL_URL}v${KVER}/$ALL_DEB
+  - sudo dpkg -i *.deb
+
+script:
+  - make CC=$COMPILER KVER=$KVER_BUILD-generic CONFIG_PLATFORM_I386_PC=y
+env:
+  global:
+    - KERNEL_URL=http://kernel.ubuntu.com/~kernel-ppa/mainline/
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - libelf-dev
+      env: COMPILER=gcc-5 KVER=4.19-rc1
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - libelf-dev
+      env: COMPILER=gcc-6 KVER=4.19-rc1
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+            - libelf-dev
+      env: COMPILER=gcc-7 KVER=4.19-rc1
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - libelf-dev
+      env: COMPILER=gcc-5 KVER=4.14.67
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5 KVER=3.14.79

--- a/include/wifi.h
+++ b/include/wifi.h
@@ -994,8 +994,9 @@ typedef enum _HT_CAP_AMPDU_FACTOR {
  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
  */
 #define IEEE80211_MIN_AMPDU_BUF 0x8
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
 #define IEEE80211_MAX_AMPDU_BUF 0x40
-
+#endif
 
 /* Spatial Multiplexing Power Save Modes */
 #define WLAN_HT_CAP_SM_PS_STATIC		0

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -699,7 +699,11 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
  
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) 	
-				, void *accel_priv
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+				, struct net_device *sb_dev
+#else
+                                , void *accel_priv
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) 
 				, select_queue_fallback_t fallback
 #endif


### PR DESCRIPTION
Fix buid for kernel 4.19 RC-1
Updated travis to last LTS

Based on #18 

ping @sergey-suloev for testing
[Build logs](https://travis-ci.org/CGarces/rtl8189ES_linux/builds/435210658) indicate the the driver not is compatible with 3.14, I'll try to fix it latter.