### PR TITLE
Feature/kernel 4 20 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ sudo: required
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y dpkg  # to upgrade to dpkg >= 1.17.5ubuntu5.8, which fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
-  - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
-  - sudo dpkg -i libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
-  - rm libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
   - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
   - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
   - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)
@@ -27,37 +24,45 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-5
             - libelf-dev
-      env: COMPILER=gcc-5 KVER=4.19-rc1
+            - libssl1.1
+      env: COMPILER=gcc-5 KVER=4.20.11
     - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-6
             - libelf-dev
-      env: COMPILER=gcc-6 KVER=4.19-rc1
+            - libssl1.1
+      env: COMPILER=gcc-6 KVER=4.20.11
     - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-7
             - libelf-dev
-      env: COMPILER=gcc-7 KVER=4.19-rc1
+            - libssl1.1
+      env: COMPILER=gcc-7 KVER=4.20.11
     - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
-            - gcc-5
+            - gcc-7
             - libelf-dev
-      env: COMPILER=gcc-5 KVER=4.14.67
+            - libssl1.1
+      env: COMPILER=gcc-7 KVER=4.19.24
     - compiler: gcc
       addons:
         apt:

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -347,7 +347,10 @@ rtw_cfg80211_default_mgmt_stypes[NUM_NL80211_IFTYPES] = {
 
 static u64 rtw_get_systime_us(void)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0))
+       struct timespec ts = ktime_to_timespec(ktime_get_boottime());
+       return ((u64)ts.tv_sec*1000000) + ts.tv_nsec / 1000;
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39))
 	struct timespec ts;
 	get_monotonic_boottime(&ts);
 	return ((u64)ts.tv_sec*1000000) + ts.tv_nsec / 1000;


### PR DESCRIPTION
Compile fails on Kernel 4.20 due to removal of get_monotonic_boottime.

Some changes in this PR are due to line-ending changes, I'm not quite sure what caused them, it seems that the file used mixed line endings, I could not figure out how to change the file without these line-ending changes.