### PR TITLE
fix AP crash on 4.20

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3679,6 +3679,7 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 			ie_offset = _REASOCREQ_IE_OFFSET_;
 	
 		sinfo.filled = 0;
+		sinfo.pertid = 0;
 		sinfo.filled = STATION_INFO_ASSOC_REQ_IES;
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3679,7 +3679,9 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 			ie_offset = _REASOCREQ_IE_OFFSET_;
 	
 		sinfo.filled = 0;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0))
 		sinfo.pertid = 0;
+#endif
 		sinfo.filled = STATION_INFO_ASSOC_REQ_IES;
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;


### PR DESCRIPTION
Fixes crash during connecting to access point on rtl8189FS and reset system.

Here stacktrace:
```
[19:20:30:869] [   62.957051] ------------[ cut here ]------------␍␊
[19:20:30:876] [   62.961903] kernel BUG at mm/slub.c:3937!␍␊
[19:20:30:876] [   62.966333] Internal error: Oops - BUG: 0 [#1] PREEMPT SMP ARM␍␊
[19:20:30:886] [   62.972551] Modules linked in: 8189fs(O) sun8i_codec_analog sun8i_drm_hdmi mali(O) sun8i_adda_pr_regmap dw_hdmi cfg80211 sun4i_gpadc_iio sunxi_cedrus(C) cdc_mbim videobuf2_dma_contig videobuf2_memops v4l2_mem2mem videobuf2_v4l2 videobuf2_common sun4i_drm cpufreq_dt sun4i_frontend sun8i_mixer thermal_sys sun4i_tcon sun8i_tcon_top␍␊
[19:20:30:920] [   63.003853] CPU: 2 PID: 354 Comm: RTW_CMD_THREAD Tainted: G         C O      4.20.17 #3␍␊
[19:20:30:928] [   63.012050] Hardware name: Allwinner sun8i Family␍␊
[19:20:30:928] [   63.016761] PC is at kfree+0x244/0x264␍␊
[19:20:30:937] [   63.020656] LR is at nl80211_send_station+0xb20/0xd0c [cfg80211]␍␊
[19:20:30:937] [   63.026658] pc : [<c0284f84>]    lr : [<bf0d6a04>]    psr: 40030013␍␊
[19:20:30:946] [   63.032917] sp : ed471d18  ip : ed471d48  fp : ed471d44␍␊
[19:20:30:946] [   63.038136] r10: 00000000  r9 : ef1b7030  r8 : c012b9a0␍␊
[19:20:30:955] [   63.043356] r7 : ef7cb560  r6 : ef1b7014  r5 : c012b9a0  r4 : bf0d6a04␍␊
[19:20:30:964] [   63.049875] r3 : ef7cb564  r2 : 00000000  r1 : ed819e7c  r0 : 0000012b␍␊
[19:20:30:973] [   63.056397] Flags: nZcv  IRQs on  FIQs on  Mode SVC_32  ISA ARM  Segment none␍␊
[19:20:30:973] [   63.063523] Control: 10c5387d  Table: 6d47406a  DAC: 00000051␍␊
[19:20:30:984] [   63.069268] Process RTW_CMD_THREAD (pid: 354, stack limit = 0x57beab22)␍␊
[19:20:30:984] [   63.075868] Stack: (0xed471d18 to 0xed472000)␍␊
[19:20:30:997] [   63.080223] 1d00:                                                       ed819e1c c05d291c␍␊
[19:20:30:997] [   63.088398] 1d20: c0f06888 ee77a180 ef1b7014 ed471df0 c012b9a0 ef1b7030 ed471da4 ed471d48␍␊
[19:20:31:015] [   63.096572] 1d40: bf0d6a04 c0284d4c 00000005 00000013 00000000 ef1b7030 ef1b7238 00000000␍␊
[19:20:31:015] [   63.104744] 1d60: ef1b7034 ef1b7014 e34c00c7 e5832000 00471d94 48c19afb c017df10 edbc71a0␍␊
[19:20:31:027] [   63.112916] 1d80: edbc6800 00000000 00480020 ed819e0a ed471df0 ee77a180 ed471dec ed471da8␍␊
[19:20:31:039] [   63.121087] 1da0: bf0d6f78 bf0d5ef0 00000000 edbc7000 edbc6800 ed819e0a ed471df0 c017eae0␍␊
[19:20:31:039] [   63.129260] 1dc0: ed471de4 00000060 ed819e00 edbc6800 ed819e00 bf2d5000 bf2b08b0 bf1fc0a0␍␊
[19:20:31:050] [   63.137430] 1de0: ed471ecc ed471df0 bf239810 bf0d6ef4 00000000 00000000 ed471e8c ed471e08␍␊
[19:20:31:062] [   63.145602] 1e00: c02845c8 c0150470 c0fd0c80 00000001 ed471e5c ecd4db00 c0f06888 c017da9c␍␊
[19:20:31:062] [   63.153775] 1e20: 00210d00 00000001 8020001b ecd4db00 00000001 ffffe000 c0f06888 00000000␍␊
[19:20:31:073] [   63.161946] 1e40: c0acbe3c bf2b0718 bf2d5000 bf2b08b0 8020001b ed471e60 ed819e1c 00000060␍␊
[19:20:31:084] [   63.170118] 1e60: ed471ea4 bf221cb8 ecd4db00 ef001d80 efd639a0 ffffe000 001fff00 ffffe000␍␊
[19:20:31:096] [   63.178312] 1e80: 0000007c ed819e00 ed471ea4 ed471e98 c0592b08 c012b9a0 ed471ebc ed471ea8␍␊
[19:20:31:096] [   63.186511] 1ea0: c012b9a0 c0150470 f0b73000 48c19afb ed471ecc f0b73000 f0ec5204 0000007c␍␊
[19:20:31:108] [   63.194711] 1ec0: ed471f04 ed471ed0 bf1ecd2c bf239780 c0174dc0 c0acbf74 f0b74140 bf2b0718␍␊
[19:20:31:119] [   63.202904] 1ee0: ef0ef000 ef0ef000 bf2aa3f4 ee6ae200 f0b73000 bf2b0718 ed471f24 ed471f08␍␊
[19:20:31:119] [   63.211082] 1f00: bf1fc128 bf1ecb9c ecd482c0 f0b73000 f0b74140 bf2b0718 ed471f74 ed471f28␍␊
[19:20:31:131] [   63.219253] 1f20: bf1d20bc bf1fc0ac ed471f4c c0acbfa0 ed471f4c f0b74130 f0b7416c ee6ae200␍␊
[19:20:31:142] [   63.227426] 1f40: f0b74120 fffc61ad c01476ec ed445900 ed8c9ec0 00000000 ed470000 f0b73000␍␊
[19:20:31:155] [   63.235596] 1f60: bf1d1b64 ee235794 ed471fac ed471f78 c0147be4 bf1d1b70 ed44591c ed44591c␍␊
[19:20:31:155] [   63.243767] 1f80: 00000000 ed8c9ec0 c0147a78 00000000 00000000 00000000 00000000 00000000␍␊
[19:20:31:170] [   63.251938] 1fa0: 00000000 ed471fb0 c01010e8 c0147a84 00000000 00000000 00000000 00000000␍␊
[19:20:31:170] [   63.260108] 1fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000␍␊
[19:20:31:182] [   63.268279] 1fe0: 00000000 00000000 00000000 00000000 00000013 00000000 00000000 00000000␍␊
[19:20:31:193] [   63.276443] Backtrace: ␍␊
[19:20:31:193] [   63.279026] [<c0284d40>] (kfree) from [<bf0d6a04>] (nl80211_send_station+0xb20/0xd0c [cfg80211])␍␊
[19:20:31:206] [   63.287810]  r9:ef1b7030 r8:c012b9a0 r7:ed471df0 r6:ef1b7014 r5:ee77a180 r4:c0f06888␍␊
[19:20:31:206] [   63.295655] [<bf0d5ee4>] (nl80211_send_station [cfg80211]) from [<bf0d6f78>] (cfg80211_new_sta+0x90/0x1c4 [cfg80211])␍␊
[19:20:31:218] [   63.306255]  r10:ee77a180 r9:ed471df0 r8:ed819e0a r7:00480020 r6:00000000 r5:edbc6800␍␊
[19:20:31:235] [   63.314073]  r4:edbc71a0␍␊
[19:20:31:235] [   63.317079] [<bf0d6ee8>] (cfg80211_new_sta [cfg80211]) from [<bf239810>] (rtw_cfg80211_indicate_sta_assoc+0x9c/0xc4 [8189fs])␍␊
[19:20:31:247] [   63.328376]  r10:bf1fc0a0 r9:bf2b08b0 r8:bf2d5000 r7:ed819e00 r6:edbc6800 r5:ed819e00␍␊
[19:20:31:247] [   63.336196]  r4:00000060␍␊
[19:20:31:247] [   63.339081] [<bf239774>] (rtw_cfg80211_indicate_sta_assoc [8189fs]) from [<bf1ecd2c>] (rtw_stassoc_event_callback+0x19c/0x25c [8189fs])␍␊
[19:20:31:261] [   63.351241]  r6:0000007c r5:f0ec5204 r4:f0b73000␍␊
[19:20:31:272] [   63.356167] [<bf1ecb90>] (rtw_stassoc_event_callback [8189fs]) from [<bf1fc128>] (mlme_evt_hdl+0x88/0xa0 [8189fs])␍␊
[19:20:31:285] [   63.366503]  r7:bf2b0718 r6:f0b73000 r5:ee6ae200 r4:bf2aa3f4␍␊
[19:20:31:285] [   63.372446] [<bf1fc0a0>] (mlme_evt_hdl [8189fs]) from [<bf1d20bc>] (rtw_cmd_thread+0x558/0x688 [8189fs])␍␊
[19:20:31:297] [   63.381919]  r7:bf2b0718 r6:f0b74140 r5:f0b73000 r4:ecd482c0␍␊
[19:20:31:297] [   63.387748] [<bf1d1b64>] (rtw_cmd_thread [8189fs]) from [<c0147be4>] (kthread+0x16c/0x174)␍␊
[19:20:31:310] [   63.396008]  r10:ee235794 r9:bf1d1b64 r8:f0b73000 r7:ed470000 r6:00000000 r5:ed8c9ec0␍␊
[19:20:31:321] [   63.403826]  r4:ed445900␍␊
[19:20:31:321] [   63.406367] [<c0147a78>] (kthread) from [<c01010e8>] (ret_from_fork+0x14/0x2c)␍␊
[19:20:31:334] [   63.413580] Exception stack(0xed471fb0 to 0xed471ff8)␍␊
[19:20:31:334] [   63.418628] 1fa0:                                     00000000 00000000 00000000 00000000␍␊
[19:20:31:346] [   63.426799] 1fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000␍␊
[19:20:31:346] [   63.435004] 1fe0: 00000000 00000000 00000000 00000000 00000013 00000000␍␊
[19:20:31:358] [   63.441654]  r10:00000000 r9:00000000 r8:00000000 r7:00000000 r6:00000000 r5:c0147a78␍␊
[19:20:31:358] [   63.449490]  r4:ed8c9ec0␍␊
[19:20:31:373] [   63.452036] Code: 1a000003 e5973004 e3130001 1a000000 (e7f001f2) ␍␊
[19:20:31:373] [   63.458130] ---[ end trace a03436ec08239873 ]---␍␊
```

I followed thread: https://forum.armbian.com/topic/8241-wifi-access-point-hostapd-with-kernel-418-and-419/

and added patch from armbian: https://github.com/armbian/build/commit/e5b292799bdda76097367742653da9a3bd951086

I don't know what this patch does but it works for me on kernel 4.20
