### PR TITLE
Fix Travis test and fix compilation for kernel >= 3.13 and < 5.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: c
 compiler: gcc
 sudo: required
+dist: xenial
 
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y dpkg  # to upgrade to dpkg >= 1.17.5ubuntu5.8, which fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
   - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
   - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
   - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)
   - wget ${KERNEL_URL}v${KVER}/$ALL_DEB
-  - wget "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb"
   - sudo dpkg -i *.deb
 
 script:
@@ -24,11 +22,9 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
-            - gcc-5
-            - libelf-dev
+            - libssl1.1
       env: COMPILER=gcc-5 KVER=5.2-rc4
     - compiler: gcc
       addons:
@@ -38,7 +34,7 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-6
-            - libelf-dev
+            - libssl1.1
       env: COMPILER=gcc-6 KVER=5.2-rc4
     - compiler: gcc
       addons:
@@ -48,18 +44,16 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-7
-            - libelf-dev
+            - libssl1.1
       env: COMPILER=gcc-7 KVER=5.2-rc4
     - compiler: gcc
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
-            - gcc-5
-            - libelf-dev
-      env: COMPILER=gcc-5 KVER=5.0.1
+            - libssl1.1
+      env: COMPILER=gcc-5 KVER=5.1.9
     - compiler: gcc
       addons:
         apt:
@@ -68,8 +62,8 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-6
-            - libelf-dev
-      env: COMPILER=gcc-6 KVER=5.0.1
+            - libssl1.1
+      env: COMPILER=gcc-6 KVER=5.1.9
     - compiler: gcc
       addons:
         apt:
@@ -78,18 +72,16 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-7
-            - libelf-dev
-      env: COMPILER=gcc-7 KVER=5.0.1
+            - libssl1.1
+      env: COMPILER=gcc-7 KVER=5.1.9
     - compiler: gcc
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
-            - gcc-5
-            - libelf-dev
-      env: COMPILER=gcc-5 KVER=4.20.11
+            - libssl1.1
+      env: COMPILER=gcc-5 KVER=4.19.50
     - compiler: gcc
       addons:
         apt:
@@ -98,8 +90,8 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-6
-            - libelf-dev
-      env: COMPILER=gcc-6 KVER=4.20.11
+            - libssl1.1
+      env: COMPILER=gcc-6 KVER=4.19.50
     - compiler: gcc
       addons:
         apt:
@@ -108,23 +100,7 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-7
-            - libelf-dev
-      env: COMPILER=gcc-7 KVER=4.20.11
+            - libssl1.1
+      env: COMPILER=gcc-7 KVER=4.19.50
     - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-7
-            - libelf-dev
-      env: COMPILER=gcc-7 KVER=4.19.24
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-5
       env: COMPILER=gcc-5 KVER=3.14.79

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
   - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)
   - wget ${KERNEL_URL}v${KVER}/$ALL_DEB
+  - wget "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb"
   - sudo dpkg -i *.deb
 
 script:
@@ -28,7 +29,36 @@ matrix:
           packages:
             - gcc-5
             - libelf-dev
-            - libssl1.1
+      env: COMPILER=gcc-5 KVER=5.2-rc4
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
+          packages:
+            - gcc-6
+            - libelf-dev
+      env: COMPILER=gcc-6 KVER=5.2-rc4
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
+          packages:
+            - gcc-7
+            - libelf-dev
+      env: COMPILER=gcc-7 KVER=5.2-rc4
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
+          packages:
+            - gcc-5
+            - libelf-dev
       env: COMPILER=gcc-5 KVER=5.0.1
     - compiler: gcc
       addons:
@@ -39,7 +69,6 @@ matrix:
           packages:
             - gcc-6
             - libelf-dev
-            - libssl1.1
       env: COMPILER=gcc-6 KVER=5.0.1
     - compiler: gcc
       addons:
@@ -50,7 +79,6 @@ matrix:
           packages:
             - gcc-7
             - libelf-dev
-            - libssl1.1
       env: COMPILER=gcc-7 KVER=5.0.1
     - compiler: gcc
       addons:
@@ -61,7 +89,6 @@ matrix:
           packages:
             - gcc-5
             - libelf-dev
-            - libssl1.1
       env: COMPILER=gcc-5 KVER=4.20.11
     - compiler: gcc
       addons:
@@ -72,7 +99,6 @@ matrix:
           packages:
             - gcc-6
             - libelf-dev
-            - libssl1.1
       env: COMPILER=gcc-6 KVER=4.20.11
     - compiler: gcc
       addons:
@@ -83,7 +109,6 @@ matrix:
           packages:
             - gcc-7
             - libelf-dev
-            - libssl1.1
       env: COMPILER=gcc-7 KVER=4.20.11
     - compiler: gcc
       addons:
@@ -94,7 +119,6 @@ matrix:
           packages:
             - gcc-7
             - libelf-dev
-            - libssl1.1
       env: COMPILER=gcc-7 KVER=4.19.24
     - compiler: gcc
       addons:

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -896,16 +896,17 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 }
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
 				, struct net_device *sb_dev
+#else
+                                , void *accel_priv
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
-	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-				, void *accel_priv
-	#endif
-	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) 
 				, select_queue_fallback_t fallback
-	#endif
+#endif
+#endif
 #endif
 )
 {


### PR DESCRIPTION
This PR fixes the Travis tests and fixes compilation for kernel 4 and 5, which were broken by #27.
I reverted that commit and used a better compile condition to support all kernels.