### PR TITLE
Make efuse dump more compact

### DIFF
--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -7288,6 +7288,7 @@ void rtw_dump_cur_efuse(PADAPTER padapter)
 {
 	int i =0;
 	int mapsize =0;
+	const char* title;
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(padapter);
 
 	EFUSE_GetEfuseDefinition(padapter, EFUSE_WIFI, TYPE_EFUSE_MAP_LEN , (void *)&mapsize, _FALSE);
@@ -7298,21 +7299,14 @@ void rtw_dump_cur_efuse(PADAPTER padapter)
 	}
 
 	if (hal_data->efuse_file_status == EFUSE_FILE_LOADED)
-		DBG_871X_LEVEL(_drv_always_, "EFUSE FILE\n");
+		title = "EFUSE FILE\n";
 	else
-		DBG_871X_LEVEL(_drv_always_, "HW EFUSE\n");
+		title = "HW EFUSE\n";
 
 #ifdef CONFIG_DEBUG
-	for (i = 0; i < mapsize; i++) {
-		if (i % 16 == 0)
-			DBG_871X_SEL_NL(RTW_DBGDUMP, "0x%03x: ", i);
-
-		DBG_871X_SEL(RTW_DBGDUMP, "%02X%s"
-			, hal_data->efuse_eeprom_data[i]
-			, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "    " : " ")
-		);
-	}
-	DBG_871X_SEL(RTW_DBGDUMP, "\n");
+	RTW_PRINT_DUMP(title, hal_data->efuse_eeprom_data, mapsize);
+#else
+	DBG_871X_LEVEL(_drv_always_, title);
 #endif
 }
 

--- a/include/rtw_debug.h
+++ b/include/rtw_debug.h
@@ -213,6 +213,14 @@ extern void rtl871x_cedbg(const char *fmt, ...);
 #define RTW_ERR(fmt, arg...) DBG_871X_LEVEL(_drv_err_, fmt, ##arg)
 
 #undef RTW_PRINT_DUMP
+#if defined PLATFORM_LINUX
+#define RTW_PRINT_DUMP(_TitleString, _HexData, _HexDataLen)			\
+	do {\
+		_dbgdump("%s%s", DRIVER_PREFIX, _TitleString);			\
+		print_hex_dump(KERN_DEFAULT, DRIVER_PREFIX, DUMP_PREFIX_OFFSET, \
+			       16, 1, _HexData, _HexDataLen, false); \
+	} while (0)
+#else
 #define RTW_PRINT_DUMP(_TitleString, _HexData, _HexDataLen)			\
 	do {\
 		int __i;								\
@@ -226,6 +234,7 @@ extern void rtl871x_cedbg(const char *fmt, ...);
 		}								\
 		_dbgdump("\n"); 						\
 	} while (0)
+#endif
 
 #undef RTW_INFO_DUMP
 #define RTW_INFO_DUMP RTW_PRINT_DUMP


### PR DESCRIPTION
Following enforcement of newlines in printk, the rtl8189fs driver now dumps the efuse one byte per line. This unnecessarily floods the kernel logs.
Switch to RTW_PRINT_DATA() with print_hex_dump() on Linux to get rid of this without reworking the RTL HAL layer.
On FreeBSD one can switch to hexdump(9), though this is not covered here.