### PR TITLE
Move 3 functions from header into the source file

### DIFF
--- a/core/rtw_ieee80211.c
+++ b/core/rtw_ieee80211.c
@@ -25,6 +25,22 @@
 #include <drv_types.h>
 #include <linux/of.h>
 
+__inline int is_multicast_mac_addr(const u8 *addr)
+{
+        return ((addr[0] != 0xff) && (0x01 & addr[0]));
+}
+
+__inline int is_broadcast_mac_addr(const u8 *addr)
+{
+	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
+		(addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
+}
+
+__inline int is_zero_mac_addr(const u8 *addr)
+{
+	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
+		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));
+}
 
 u8 RTW_WPA_OUI_TYPE[] = { 0x00, 0x50, 0xf2, 1 };
 u16 RTW_WPA_VERSION = 1;

--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -1477,22 +1477,11 @@ enum ieee80211_state {
 (((Addr[2]) & 0xff) == 0xff) && (((Addr[3]) & 0xff) == 0xff) && (((Addr[4]) & 0xff) == 0xff) && \
 (((Addr[5]) & 0xff) == 0xff))
 #else
-extern __inline int is_multicast_mac_addr(const u8 *addr)
-{
-        return ((addr[0] != 0xff) && (0x01 & addr[0]));
-}
+extern __inline int is_multicast_mac_addr(const u8 *addr);
 
-extern __inline int is_broadcast_mac_addr(const u8 *addr)
-{
-	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
-		(addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
-}
+extern __inline int is_broadcast_mac_addr(const u8 *addr);
 
-extern __inline int is_zero_mac_addr(const u8 *addr)
-{
-	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
-		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));
-}
+extern __inline int is_zero_mac_addr(const u8 *addr);
 #endif //PLATFORM_FREEBSD
 
 #define CFG_IEEE80211_RESERVE_FCS (1<<0)


### PR DESCRIPTION
Fixes build with clang 9.0.3

```
  LD [M]  obj/RTL8189FTV-MOD/8189fs.o
  Building modules, stage 2.
  MODPOST 1 modules
ERROR: "is_broadcast_mac_addr" [obj/RTL8189FTV-MOD/8189fs.ko] undefined!
ERROR: "is_zero_mac_addr" [obj/RTL8189FTV-MOD/8189fs.ko] undefined!
ERROR: "is_multicast_mac_addr" [obj/RTL8189FTV-MOD/8189fs.ko] undefined!
kernel/glodroid/scripts/Makefile.modpost:113: recipe for target '__modpost' failed
make[3]: *** [__modpost] Error 1
kernel/glodroid/Makefile:1672: recipe for target 'modules' failed
make[2]: *** [modules] Error 2
kernel/glodroid/Makefile:179: recipe for target 'sub-make' failed
make[1]: *** [sub-make] Error 2
```

Signed-off-by: Roman Stratiienko <roman.stratiienko@globallogic.com>