### PR TITLE
Use ktime_to_us() instead of ktime_to_timespec() and computing to us

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 compiler: gcc
 sudo: required
-dist: xenial
+dist: bionic
 
 before_install:
   - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
@@ -22,85 +22,43 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: 'ppa:ondrej/nginx-mainline'
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
-            - libssl1.1
-      env: COMPILER=gcc-5 KVER=5.2-rc4
+            - gcc-9
+      env: COMPILER=gcc-9 KVER=5.6-rc7
+    - compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-8
+      env: COMPILER=gcc-8 KVER=5.6-rc7
+ #No longer builds on gcc-7.4 should be fixed by gcc-7.5
+ #    - compiler: gcc
+ #     env: COMPILER=gcc-7 KVER=5.6-rc7
     - compiler: gcc
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
-            - gcc-6
-            - libssl1.1
-      env: COMPILER=gcc-6 KVER=5.2-rc4
+            - gcc-9
+      env: COMPILER=gcc-9 KVER=5.4.28
     - compiler: gcc
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
-            - gcc-7
-            - libssl1.1
-      env: COMPILER=gcc-7 KVER=5.2-rc4
+            - gcc-8
+      env: COMPILER=gcc-8 KVER=5.4.28
+#No longer builds on gcc-7.4 should be fixed by gcc-7.5
+ #   - compiler: gcc
+ #     env: COMPILER=gcc-7 KVER=5.4.28
     - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - libssl1.1
-      env: COMPILER=gcc-5 KVER=5.1.9
+      env: COMPILER=gcc-7 KVER=4.19.113
     - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-6
-            - libssl1.1
-      env: COMPILER=gcc-6 KVER=5.1.9
+      env: COMPILER=gcc-7 KVER=4.14.174
     - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-7
-            - libssl1.1
-      env: COMPILER=gcc-7 KVER=5.1.9
+      env: COMPILER=gcc-7 KVER=4.9.217
     - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - libssl1.1
-      env: COMPILER=gcc-5 KVER=4.19.50
+      env: COMPILER=gcc-7 KVER=4.4.217
     - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-6
-            - libssl1.1
-      env: COMPILER=gcc-6 KVER=4.19.50
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-7
-            - libssl1.1
-      env: COMPILER=gcc-7 KVER=4.19.50
-    - compiler: gcc
-      env: COMPILER=gcc-5 KVER=3.14.79
+      env: COMPILER=gcc-7 KVER=3.16.82

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -348,8 +348,7 @@ rtw_cfg80211_default_mgmt_stypes[NUM_NL80211_IFTYPES] = {
 static u64 rtw_get_systime_us(void)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0))
-       struct timespec ts = ktime_to_timespec(ktime_get_boottime());
-       return ((u64)ts.tv_sec*1000000) + ts.tv_nsec / 1000;
+	return (u64)ktime_to_us(ktime_get_boottime());
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39))
 	struct timespec ts;
 	get_monotonic_boottime(&ts);


### PR DESCRIPTION
struct timespec is being dropped in the 5.6-rc cycle. Since
ktime_to_us() has been around for much longer, use that instead.

Signed-off-by: Chen-Yu Tsai <wens@csie.org>