### PR TITLE
Use ktime_to_us() instead of ktime_to_timespec() and computing to us

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -349,8 +349,7 @@ rtw_cfg80211_default_mgmt_stypes[NUM_NL80211_IFTYPES] = {
 static u64 rtw_get_systime_us(void)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0))
-	struct timespec ts = ktime_to_timespec(ktime_get_boottime());
-	return ((u64)ts.tv_sec*1000000) + ts.tv_nsec / 1000;
+	return (u64)ktime_to_us(ktime_get_boottime());
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39))
 	struct timespec ts;
 	get_monotonic_boottime(&ts);


### PR DESCRIPTION
struct timespec is being dropped in the 5.6-rc cycle. Since
ktime_to_us() has been around for much longer, use that instead.

Signed-off-by: Chen-Yu Tsai <wens@csie.org>