### PR TITLE
Downgraded github action build to 18.04 due mising libssl1.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
   build:
     needs: fetchKernelData
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04 #need due mising libssl1.0.0
     strategy:
       matrix: 
         version: ${{fromJson(needs.fetchKernelData.outputs.matrix)}}


### PR DESCRIPTION
Github action works fine on 18.04
https://github.com/CGarces/rtl8189ES_linux/actions/runs/438031853
but fails on 20.04
https://github.com/jwrdegoede/rtl8189ES_linux/actions/runs/438025065

Note that both build has been done the same day but Ubuntu choose a diferent version for  `ubuntu-latest`

In order to fix the problem and made the build stage reproducible (I don't know how Github choose 18.04 or 20.04) y have hardcoded 18.04.

Sorry for the noise.