### PR TITLE
Fix compatibility issues with cfg80211 on OpenWrt

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3670,18 +3670,15 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 
 #if defined(RTW_USE_CFG80211_STA_EVENT) || defined(COMPAT_KERNEL_RELEASE)
 	{
-		struct station_info sinfo;
+		struct station_info sinfo = {
+			.filled = STATION_INFO_ASSOC_REQ_IES,
+		};
 		u8 ie_offset;
 		if (GetFrameSubType(pmgmt_frame) == WIFI_ASSOCREQ)
 			ie_offset = _ASOCREQ_IE_OFFSET_;
 		else // WIFI_REASSOCREQ
 			ie_offset = _REASOCREQ_IE_OFFSET_;
 	
-		sinfo.filled = 0;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0))
-		sinfo.pertid = 0;
-#endif
-		sinfo.filled = STATION_INFO_ASSOC_REQ_IES;
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;
 		cfg80211_new_sta(ndev, GetAddr2Ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);


### PR DESCRIPTION
Port of #52 by @lyh802 

jgrulich reports a bug:
The rtl8189 and similar drivers are not compatible with commit mac80211: rebase ontop of v4.18.5 and newer
https://forum.openwrt.org/t/the-rtl8189-and-similar-drivers-are-not-compatible-with-commit-mac80211-rebase-ontop-of-v4-18-5-and-newer/31034

refer: https://github.com/abperiasamy/rtl8812AU_8821AU_linux/commit/076ac48d9457e947f50835b38dfc616ac9ab210b
saiarcot895 authored and harshavardhana committed on 11 Jan 2019:
* Add explicit memset call to avoid potentially corrupt data. (#277)
In kernel 4.19, I saw a kernel crash where kfree was trying to free
some garbage pointer. This occurred because this structure wasn't
explicitly initialized to 0.