### PR TITLE
Implemented CI with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on: [pull_request]
+
+jobs:
+  fetchKernelData:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - id: set-matrix
+      run: |
+        JSON=$(curl https://www.kernel.org/releases.json)
+        VERSIONSARRAY=$(echo $JSON | jq -c '[.releases[] | {version: .version, moniker: .moniker} | select(.moniker != "linux-next") | .version]')
+        echo ::set-output name=matrix::${VERSIONSARRAY}
+
+  build:
+    needs: fetchKernelData
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: 
+        version: ${{fromJson(needs.fetchKernelData.outputs.matrix)}}
+        #version: [4.9.248, 4.4.248]
+    steps:
+    - uses: actions/checkout@v2
+    - name: download-Kernel
+      env: 
+        VERSION: ${{matrix.version }}
+      run: |
+        KERNEL_URL=https://kernel.ubuntu.com/~kernel-ppa/mainline/
+        KERNEL_URL_DETAILS=$(wget --quiet -O - ${KERNEL_URL}v${VERSION}/ | grep -A8 "Build for amd64\|Test amd64")
+        ALL_DEB=$(echo "$KERNEL_URL_DETAILS" |  grep -m1 'all.deb' | cut -d '"' -f 2)
+        KVER=$(echo $ALL_DEB | cut -d '_' -f 2 | rev | cut -c14- | rev)-generic
+        wget -nv ${KERNEL_URL}v${VERSION}/$(echo "$KERNEL_URL_DETAILS" | grep -m1 "amd64.deb" | cut -d '"' -f 2)
+        wget -nv ${KERNEL_URL}v${VERSION}/$ALL_DEB
+        sudo dpkg --force-all -i *.deb
+        echo "KVER=$KVER" >> $GITHUB_ENV
+    - name: build
+      run: make KVER=$KVER CONFIG_PLATFORM_I386_PC=y


### PR DESCRIPTION
Implemented github action to build the code over the last versions from https://kernel.ubuntu.com/~kernel-ppa/mainline/
Note that builds from kernel-ppa sometimes fails and .deb files not are always available, so github action may fail.