### PR TITLE
Fix libc6 dependency 2.34

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         KVER=$(echo $ALL_DEB | cut -d '_' -f 2 | rev | cut -c14- | rev)-generic
         wget -nv ${KERNEL_URL}v${VERSION}/$(echo "$KERNEL_URL_DETAILS" | grep -m1 "amd64.deb" | cut -d '"' -f 2)
         wget -nv ${KERNEL_URL}v${VERSION}/$ALL_DEB
+        wget -nv http://mirrors.kernel.org/ubuntu/pool/main/g/glibc/libc6_2.34-0ubuntu2_amd64.deb
         sudo dpkg --force-all -i *.deb
         echo "KVER=$KVER" >> $GITHUB_ENV
     - name: build


### PR DESCRIPTION
Partial fix for CI.

Adds libc6 2.34 from Ubuntu impish.
See https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1926938 for details.
The build still failing because kernels from https://kernel.ubuntu.com/~kernel-ppa/mainline/ not are always build correctly.