### PR TITLE
Fix epic crashes on RT kernels

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -130,7 +130,11 @@
 #endif
 
 	typedef struct 	semaphore _sema;
+#ifdef CONFIG_PREEMPT_RT
+	typedef	raw_spinlock_t	_lock;
+#else
 	typedef	spinlock_t	_lock;
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37))
 	typedef struct mutex 		_mutex;
 #else
@@ -220,32 +224,56 @@ __inline static _list	*get_list_head(_queue	*queue)
         
 __inline static void _enter_critical(_lock *plock, _irqL *pirqL)
 {
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_lock_irqsave(plock, *pirqL);
+#else
 	spin_lock_irqsave(plock, *pirqL);
+#endif
 }
 
 __inline static void _exit_critical(_lock *plock, _irqL *pirqL)
 {
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_unlock_irqrestore(plock, *pirqL);
+#else
 	spin_unlock_irqrestore(plock, *pirqL);
+#endif
 }
 
 __inline static void _enter_critical_ex(_lock *plock, _irqL *pirqL)
 {
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_lock_irqsave(plock, *pirqL);
+#else
 	spin_lock_irqsave(plock, *pirqL);
+#endif
 }
 
 __inline static void _exit_critical_ex(_lock *plock, _irqL *pirqL)
 {
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_unlock_irqrestore(plock, *pirqL);
+#else
 	spin_unlock_irqrestore(plock, *pirqL);
+#endif
 }
 
 __inline static void _enter_critical_bh(_lock *plock, _irqL *pirqL)
 {
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_lock_bh(plock);
+#else
 	spin_lock_bh(plock);
+#endif
 }
 
 __inline static void _exit_critical_bh(_lock *plock, _irqL *pirqL)
 {
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_unlock_bh(plock);
+#else
 	spin_unlock_bh(plock);
+#endif
 }
 
 __inline static int _enter_critical_mutex(_mutex *pmutex, _irqL *pirqL)

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1143,7 +1143,11 @@ void	_rtw_spinlock_init(_lock *plock)
 
 #ifdef PLATFORM_LINUX
 
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_lock_init(plock);
+#else
 	spin_lock_init(plock);
+#endif
 
 #endif	
 #ifdef PLATFORM_FREEBSD
@@ -1198,7 +1202,11 @@ void	_rtw_spinlock(_lock	*plock)
 
 #ifdef PLATFORM_LINUX
 
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_lock(plock);
+#else
 	spin_lock(plock);
+#endif
 
 #endif
 #ifdef PLATFORM_FREEBSD
@@ -1217,7 +1225,11 @@ void	_rtw_spinunlock(_lock *plock)
 
 #ifdef PLATFORM_LINUX
 
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_unlock(plock);
+#else
 	spin_unlock(plock);
+#endif
 
 #endif
 #ifdef PLATFORM_FREEBSD
@@ -1236,7 +1248,11 @@ void	_rtw_spinlock_ex(_lock	*plock)
 
 #ifdef PLATFORM_LINUX
 
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_lock(plock);
+#else
 	spin_lock(plock);
+#endif
 
 #endif
 #ifdef PLATFORM_FREEBSD
@@ -1255,7 +1271,11 @@ void	_rtw_spinunlock_ex(_lock *plock)
 
 #ifdef PLATFORM_LINUX
 
+#ifdef CONFIG_PREEMPT_RT
+	raw_spin_unlock(plock);
+#else
 	spin_unlock(plock);
+#endif
 
 #endif
 #ifdef PLATFORM_FREEBSD


### PR DESCRIPTION
This is an conservative fix to avoid RT kernel crashes.
It simply substitutes all spinlocks with raw_spinlocks.

There might be a more genius fix of this and thus making the driver more RT aware.
Please contact me, if you improved it - I also would like to benefit from...

Signed-off-by: Stephan Baerwolf <stephan@matrixstorm.com>