### PR TITLE
Add kernel 5.17+ patch for RTL8189FS

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -167,7 +167,11 @@
 	typedef int		thread_return;
 	typedef void*	thread_context;
 
-	#define thread_exit() complete_and_exit(NULL, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))
+	#define thread_exit() kthread_complete_and_exit(NULL, 0);
+#else
+	#define thread_exit() complete_and_exit(NULL, 0);
+#endif
 
 	typedef void timer_hdl_return;
 	typedef void* timer_hdl_context;

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -37,6 +37,10 @@ inline struct proc_dir_entry *get_rtw_drv_proc(void)
 
 #define RTW_PROC_NAME DRV_NAME
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))
+#define PDE_DATA(inode) pde_data(inode)
+#endif
+
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,9,0))
 #define file_inode(file) ((file)->f_dentry->d_inode)
 #endif


### PR DESCRIPTION
- PDE_DATA renamed to pde_data
- complete_and_exit() renamed to kthread_complete_and_exit

Cherry-pick from https://github.com/jwrdegoede/rtl8189ES_linux/pull/66