### PR TITLE
rtl8189fs: Fix p2p-go advertising

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4952,6 +4952,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
 	ret = rtw_add_beacon(adapter, settings->beacon.head, settings->beacon.head_len,
 		settings->beacon.tail, settings->beacon.tail_len);
 
+	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
+	if (ret == 0) {
+		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
+			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
+		
+		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
+			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
+	}
+
 	if (settings->ssid && settings->ssid_len) {
 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
@@ -4985,6 +4994,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
 	RTW_INFO(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
 
 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+
+	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
+	if (ret == 0) {
+		if (info->proberesp_ies && info->proberesp_ies_len > 0)
+			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
+		
+		if (info->assocresp_ies && info->assocresp_ies_len > 0)
+			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
+	}
 
 	return ret;
 }


### PR DESCRIPTION
I'm trying to use WiFi P2P group owner on this driver, but my p2p access point looks like regular access point and not listed in "WiFi Direct" list on Android phone.

Main reason of this problem - "p2p ie" from wpa_supplicant not passed into wifi beacon

I found other driver where p2p_go works fine (but for other chip) https://github.com/aircrack-ng/rtl8812au

And I make diff of **os_dep/linux/ioctl_cfg80211.c**
```diff
 	ret = rtw_add_beacon(adapter, settings->beacon.head, settings->beacon.head_len,
 		settings->beacon.tail, settings->beacon.tail_len);
 
+        // In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
+        if(ret == 0) {
+                if(settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0) {
+                        rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *)settings->beacon.proberesp_ies,
+                                settings->beacon.proberesp_ies_len, 0x2/*PROBE_RESP*/);
+                }
+                if(settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len < 0) {
+                        rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *)settings->beacon.assocresp_ies,
+                                settings->beacon.assocresp_ies_len, 0x4/*ASSOC_RESP*/);
+                }
+        }
+
+	adapter->mlmeextpriv.mlmext_info.hidden_ssid_mode = settings->hidden_ssid;
+
 	if (settings->ssid && settings->ssid_len) {
 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
@@ -4986,9 +5214,22 @@
 
 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
 
+        // In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
+        if(ret == 0) {
+                if(info->proberesp_ies && info->proberesp_ies_len > 0) {
+                        rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *)info->proberesp_ies,
+                                info->proberesp_ies_len, 0x2/*PROBE_RESP*/);
+                }
+                if(info->assocresp_ies && info->assocresp_ies_len > 0) {
+                        rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *)info->assocresp_ies,
+                                info->assocresp_ies_len, 0x4/*ASSOC_RESP*/);
+                }
+        }
+
 	return ret;
 }
```

And after backporting of this changes p2p_go now works fine!
Now I see my orangepi on my android device in "Wi-Fi Direct" list.