### PR TITLE
rtl8189fs: Fix uninitialized cfg80211_chan_def

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -413,7 +413,7 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 
 	u8 ret = _SUCCESS;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
-	struct cfg80211_chan_def chdef;
+	struct cfg80211_chan_def chdef = {};
 
 	ret = rtw_chbw_to_cfg80211_chan_def(wiphy, &chdef, ch, bw, offset, ht);
 	if (ret != _SUCCESS)


### PR DESCRIPTION
Fix this warning in the dmesg:
```
[ 3798.246652] ------------[ cut here ]------------
[ 3798.246658] WARNING: CPU: 1 PID: 9947 at net/wireless/nl80211.c:3543 nl80211_send_chandef+0xed/0xf4 [cfg80211]
[ 3798.246944] Modules linked in: 8189fs(OE) stm32f0_pmic(OE) xt_connmark nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 xt_mark nft_counter xt_comment xt_addrtype nft_compat nf_tables nfnetlink wireguard curve25519
_neon libchacha20poly1305 chacha_neon poly1305_arm libcurve25519_generic ip6_udp_tunnel udp_tunnel sunrpc lz4hc lz4 zram binfmt_misc cfg80211 sun4i_gpadc_iio industrialio sun8i_thermal sun8i_a33_mbus rfkill cpuf
req_dt evdev uio_pdrv_genirq uio ip_tables x_tables autofs4 spidev pwm_sun4i gpio_keys display_connector sr9700 dm9601 usbnet [last unloaded: 8189fs]
[ 3798.247113] CPU: 1 PID: 9947 Comm: RTW_CMD_THREAD Tainted: G        W  OE     5.15.86-sunxi #trunk
[ 3798.247125] Hardware name: Allwinner sun8i Family
[ 3798.247138] [<c010cd21>] (unwind_backtrace) from [<c01095fd>] (show_stack+0x11/0x14)
[ 3798.247162] [<c01095fd>] (show_stack) from [<c09e3145>] (dump_stack_lvl+0x2b/0x34)
[ 3798.247182] [<c09e3145>] (dump_stack_lvl) from [<c011c439>] (__warn+0xad/0xc0)
[ 3798.247202] [<c011c439>] (__warn) from [<c09dcdd7>] (warn_slowpath_fmt+0x43/0x7c)
[ 3798.247218] [<c09dcdd7>] (warn_slowpath_fmt) from [<bf8a4a71>] (nl80211_send_chandef+0xed/0xf4 [cfg80211])
[ 3798.247358] [<bf8a4a71>] (nl80211_send_chandef [cfg80211]) from [<bf8aa2df>] (nl80211_ch_switch_notify.constprop.24+0x8f/0x134 [cfg80211])
[ 3798.247599] [<bf8aa2df>] (nl80211_ch_switch_notify.constprop.24 [cfg80211]) from [<bf8aa647>] (cfg80211_ch_switch_notify+0x7f/0xcc [cfg80211])
[ 3798.247840] [<bf8aa647>] (cfg80211_ch_switch_notify [cfg80211]) from [<bfb6528f>] (rtw_cfg80211_ch_switch_notify+0xcd/0x11e [8189fs])
[ 3798.248860] [<bfb6528f>] (rtw_cfg80211_ch_switch_notify [8189fs]) from [<bfb3e965>] (start_bss_network+0x555/0x6f4 [8189fs])
[ 3798.249719] [<bfb3e965>] (start_bss_network [8189fs]) from [<bfb288f9>] (createbss_hdl+0xa5/0xee [8189fs])
[ 3798.250559] [<bfb288f9>] (createbss_hdl [8189fs]) from [<bfb03e51>] (rtw_cmd_thread+0x395/0x4f8 [8189fs])
[ 3798.251390] [<bfb03e51>] (rtw_cmd_thread [8189fs]) from [<c0136ba3>] (kthread+0x117/0x12c)
[ 3798.251818] [<c0136ba3>] (kthread) from [<c0100139>] (ret_from_fork+0x11/0x38)
[ 3798.251834] Exception stack(0xc1d43fb0 to 0xc1d43ff8)
[ 3798.251843] 3fa0:                                     00000000 00000000 00000000 00000000
[ 3798.251853] 3fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[ 3798.251862] 3fe0: 00000000 00000000 00000000 00000000 00000013 00000000
[ 3798.251924] ---[ end trace f1d2e5f6dbf5badd ]---
```