### PR TITLE
rename get_ra

### DIFF
--- a/core/rtw_odm.c
+++ b/core/rtw_odm.c
@@ -273,7 +273,7 @@ void rtw_odm_parse_rx_phy_status_chinfo(union recv_frame *rframe, u8 *phys)
 				RTW_PRINT("phys_t%u ta="MAC_FMT" %s, %s(band:%u, ch:%u, l_rxsc:%u)\n"
 					, *phys & 0xf
 					, MAC_ARG(get_ta(wlanhdr))
-					, is_broadcast_mac_addr(get_ra(wlanhdr)) ? "BC" : is_multicast_mac_addr(get_ra(wlanhdr)) ? "MC" : "UC"
+					, is_broadcast_mac_addr(_get_ra(wlanhdr)) ? "BC" : is_multicast_mac_addr(_get_ra(wlanhdr)) ? "MC" : "UC"
 					, HDATA_RATE(attrib->data_rate)
 					, phys_t0->band, phys_t0->channel, phys_t0->rxsc
 				);
@@ -383,7 +383,7 @@ type1_end:
 				RTW_PRINT("phys_t%u ta="MAC_FMT" %s, %s(band:%u, ch:%u, rf_mode:%u, l_rxsc:%u, ht_rxsc:%u) => %u,%u\n"
 					, *phys & 0xf
 					, MAC_ARG(get_ta(wlanhdr))
-					, is_broadcast_mac_addr(get_ra(wlanhdr)) ? "BC" : is_multicast_mac_addr(get_ra(wlanhdr)) ? "MC" : "UC"
+					, is_broadcast_mac_addr(_get_ra(wlanhdr)) ? "BC" : is_multicast_mac_addr(_get_ra(wlanhdr)) ? "MC" : "UC"
 					, HDATA_RATE(attrib->data_rate)
 					, phys_t1->band, phys_t1->channel, phys_t1->rf_mode, phys_t1->l_rxsc, phys_t1->ht_rxsc
 					, pkt_cch, pkt_bw
@@ -401,7 +401,7 @@ type1_end:
 				RTW_PRINT("phys_t%u ta="MAC_FMT" %s, %s(band:%u, ch:%u, l_rxsc:%u, ht_rxsc:%u)\n"
 					, *phys & 0xf
 					, MAC_ARG(get_ta(wlanhdr))
-					, is_broadcast_mac_addr(get_ra(wlanhdr)) ? "BC" : is_multicast_mac_addr(get_ra(wlanhdr)) ? "MC" : "UC"
+					, is_broadcast_mac_addr(_get_ra(wlanhdr)) ? "BC" : is_multicast_mac_addr(_get_ra(wlanhdr)) ? "MC" : "UC"
 					, HDATA_RATE(attrib->data_rate)
 					, phys_t2->band, phys_t2->channel, phys_t2->l_rxsc, phys_t2->ht_rxsc
 				);

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -4678,7 +4678,7 @@ void rx_query_phy_status(
 	wlanhdr = get_recvframe_data(precvframe);
 
 	ta = get_ta(wlanhdr);
-	ra = get_ra(wlanhdr);
+	ra = _get_ra(wlanhdr);
 	is_ra_bmc = IS_MCAST(ra);
 
 	if (_rtw_memcmp(adapter_mac_addr(padapter), ta, ETH_ALEN) == _TRUE) {
@@ -4818,7 +4818,7 @@ s32 pre_recv_entry(union recv_frame *precvframe, u8 *pphy_status)
 {
 	s32 ret = _SUCCESS;
 	u8 *pbuf = precvframe->u.hdr.rx_data;
-	u8 *pda = get_ra(pbuf);
+	u8 *pda = _get_ra(pbuf);
 	u8 ra_is_bmc = IS_MCAST(pda);
 	_adapter *primary_padapter = precvframe->u.hdr.adapter;
 #ifdef CONFIG_CONCURRENT_MODE

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -13406,7 +13406,7 @@ void rtw_store_phy_info(_adapter *padapter, union recv_frame *prframe)
 
 			/*RTW_INFO("=>%s WIFI_DATA_TYPE or WIFI_QOS_DATA_TYPE\n", __FUNCTION__);*/
 			if (psta) {
-				if (IS_MCAST(get_ra(get_recvframe_data(prframe))))
+				if (IS_MCAST(_get_ra(get_recvframe_data(prframe))))
 					psta_dframe_info = &psta->sta_dframe_info_bmc;
 				else
 					psta_dframe_info = &psta->sta_dframe_info;

--- a/include/wifi.h
+++ b/include/wifi.h
@@ -456,7 +456,7 @@ __inline static int IS_MCAST(const u8 *da)
 		return _FALSE;
 }
 
-__inline static unsigned char *get_ra(unsigned char *pframe)
+__inline static unsigned char *_get_ra(unsigned char *pframe)
 {
 	unsigned char	*ra;
 	ra = GetAddr1Ptr(pframe);

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -6347,7 +6347,7 @@ void rtw_cfg80211_rx_p2p_action_public(_adapter *adapter, union recv_frame *rfra
 indicate:
 #endif
 	#if defined(RTW_DEDICATED_P2P_DEVICE)
-	if (rtw_cfg80211_redirect_pd_wdev(dvobj_to_wiphy(dvobj), get_ra(frame), &wdev))
+	if (rtw_cfg80211_redirect_pd_wdev(dvobj_to_wiphy(dvobj), _get_ra(frame), &wdev))
 		if (0)
 			RTW_INFO("redirect to pd_wdev:%p\n", wdev);
 	#endif


### PR DESCRIPTION
Rename `get_ra` to `_get_ra` to avoid the following build failure on powerpc raised since
https://github.com/jwrdegoede/rtl8189ES_linux/commit/89992bce4ae78f0cd277b4cc93204fb4f1937b7d:

```
In file included from /tmp/instance-5/output-1/build/rtl8189es-e58bd86c9d9408c648b1246a0dd76b16856ec172/./include/drv_types.h:29,
                 from /tmp/instance-5/output-1/build/rtl8189es-e58bd86c9d9408c648b1246a0dd76b16856ec172/./core/rtw_cmd.c:17:
/tmp/instance-5/output-1/build/rtl8189es-e58bd86c9d9408c648b1246a0dd76b16856ec172/./include/wifi.h:459:32: error: conflicting types for ‘get_ra’; have ‘unsigned char *(unsigned char *)’
  459 | __inline static unsigned char *get_ra(unsigned char *pframe)
      |                                ^~~~~~
In file included from ./arch/powerpc/include/asm/probes.h:11,
                 from ./arch/powerpc/include/asm/uprobes.h:13,
                 from ./include/linux/uprobes.h:49,
                 from ./include/linux/mm_types.h:16,
                 from ./include/linux/buildid.h:5,
                 from ./include/linux/module.h:14,
                 from /tmp/instance-5/output-1/build/rtl8189es-e58bd86c9d9408c648b1246a0dd76b16856ec172/./include/basic_types.h:76,
                 from /tmp/instance-5/output-1/build/rtl8189es-e58bd86c9d9408c648b1246a0dd76b16856ec172/./include/drv_types.h:26,
                 from /tmp/instance-5/output-1/build/rtl8189es-e58bd86c9d9408c648b1246a0dd76b16856ec172/./core/rtw_cmd.c:17:
./arch/powerpc/include/asm/disassemble.h:49:28: note: previous definition of ‘get_ra’ with type ‘unsigned int(u32)’ {aka ‘unsigned int(unsigned int)’}
   49 | static inline unsigned int get_ra(u32 inst)
      |                            ^~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/45efdb0806d0bb2f7d542be80ed02bf2dc080df4