### PR TITLE
[ES] fix build for kernel 6.16.y

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -370,7 +370,11 @@ static inline void timer_hdl(unsigned long cntx)
 #endif
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
+	_timer *ptimer = timer_container_of(ptimer, in_timer, timer);
+#else
 	_timer *ptimer = from_timer(ptimer, in_timer, timer);
+#endif
 #else
 	_timer *ptimer = (_timer *)cntx;
 #endif


### PR DESCRIPTION
The `from_timer` macro was renamed in v6.16-rc1 commit 41cb08555c416 ("treewide, timers: Rename from_timer() to timer_container_of()"). Note: this is compile tested only as I have no RTL8189ES hardware.