### PR TITLE
Fix building for Xtensa with Linux < 6.1.0 and gcc 13

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -3218,3 +3218,9 @@ int hexstr2bin(const char *hex, u8 *buf, size_t len)
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
+unsigned long long __umulsidi3(unsigned int a, unsigned int b) {
+	return (unsigned long long)a * b;
+}
+EXPORT_SYMBOL(__umulsidi3);
+#endif


### PR DESCRIPTION
Only with commit:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8939c58d68f97ce530f02d46c9f2b56c3ec88399 __umulsidi3 ha been defined, that is required by gcc 13. So let's workaround with a local defined __umulsidi3() if Linux version < 6.1.0