### PR TITLE
fix build for kernel 6.18

### DIFF
--- a/core/mesh/rtw_mesh.c
+++ b/core/mesh/rtw_mesh.c
@@ -2663,7 +2663,7 @@ exit:
 	return annc_cnt;
 }
 
-static void mpath_tx_tasklet_hdl(void *priv)
+static void mpath_tx_tasklet_hdl(unsigned long priv)
 {
 	_adapter *adapter = (_adapter *)priv;
 	struct rtw_mesh_info *minfo = &adapter->mesh_info;
@@ -3085,7 +3085,7 @@ void rtw_mesh_init_mesh_info(_adapter *adapter)
 
 	_rtw_init_queue(&minfo->mpath_tx_queue);
 	tasklet_init(&minfo->mpath_tx_tasklet
-		, (void *)mpath_tx_tasklet_hdl
+		, mpath_tx_tasklet_hdl
 		, (unsigned long)adapter);
 
 	rtw_mrc_init(adapter);

--- a/hal/rtl8188e/sdio/rtl8189es_recv.c
+++ b/hal/rtl8188e/sdio/rtl8189es_recv.c
@@ -19,7 +19,7 @@
 #include <recv_osdep.h>
 #include <rtl8188e_hal.h>
 
-static void rtl8188es_recv_tasklet(void *priv);
+static void rtl8188es_recv_tasklet(unsigned long priv);
 
 static s32 initrecvbuf(struct recv_buf *precvbuf, PADAPTER padapter)
 {
@@ -124,7 +124,7 @@ s32 rtl8188es_init_recv_priv(PADAPTER padapter)
 
 	/* 3 2. init tasklet */
 	tasklet_init(&precvpriv->recv_tasklet,
-		     (void *)rtl8188es_recv_tasklet,
+		     rtl8188es_recv_tasklet,
 		     (unsigned long)padapter);
 	goto exit;
 
@@ -194,7 +194,7 @@ void rtl8188es_free_recv_priv(PADAPTER padapter)
 }
 
 #ifdef CONFIG_SDIO_RX_COPY
-static void rtl8188es_recv_tasklet(void *priv)
+static void rtl8188es_recv_tasklet(unsigned long priv)
 {
 	PADAPTER			padapter;
 	PHAL_DATA_TYPE		pHalData;
@@ -343,7 +343,7 @@ static void rtl8188es_recv_tasklet(void *priv)
 
 }
 #else
-static void rtl8188es_recv_tasklet(void *priv)
+static void rtl8188es_recv_tasklet(unsigned long priv)
 {
 	PADAPTER				padapter;
 	PHAL_DATA_TYPE			pHalData;

--- a/hal/rtl8188e/sdio/rtl8189es_xmit.c
+++ b/hal/rtl8188e/sdio/rtl8189es_xmit.c
@@ -1013,7 +1013,7 @@ static s32 xmit_xmitframes(PADAPTER padapter, struct xmit_priv *pxmitpriv)
 	return _TRUE;
 }
 
-void rtl8188es_xmit_tasklet(void *priv)
+void rtl8188es_xmit_tasklet(unsigned long priv)
 {
 	int ret = _FALSE;
 	_adapter *padapter = (_adapter *)priv;
@@ -1502,7 +1502,7 @@ s32 rtl8188es_init_xmit_priv(PADAPTER padapter)
 
 #ifdef CONFIG_SDIO_TX_TASKLET
 	tasklet_init(&pxmitpriv->xmit_tasklet,
-		     (void *)rtl8188es_xmit_tasklet,
+		     rtl8188es_xmit_tasklet,
 		     (unsigned long)padapter);
 #else /* CONFIG_SDIO_TX_TASKLET */
 

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -419,7 +419,7 @@ static __inline void thread_enter(char *name)
 	printf("%s", "RTKTHREAD_enter");
 #endif
 }
-void thread_exit(_completion *comp);
+void __noreturn thread_exit(_completion *comp);
 void _rtw_init_completion(_completion *comp);
 void _rtw_wait_for_comp_timeout(_completion *comp);
 void _rtw_wait_for_comp(_completion *comp);

--- a/include/rtl8188e_xmit.h
+++ b/include/rtl8188e_xmit.h
@@ -252,7 +252,7 @@ void rtl8188e_cal_txdesc_chksum(struct tx_desc	*ptxdesc);
 	s32 rtl8188es_xmit_buf_handler(PADAPTER padapter);
 
 	#ifdef CONFIG_SDIO_TX_TASKLET
-		void rtl8188es_xmit_tasklet(void *priv);
+		void rtl8188es_xmit_tasklet(unsigned long priv);
 	#endif
 #endif
 

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1288,7 +1288,7 @@ u32 _rtw_down_sema(_sema *sema)
 #endif
 }
 
-inline void thread_exit(_completion *comp)
+inline void __noreturn thread_exit(_completion *comp)
 {
 #ifdef PLATFORM_LINUX
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))


### PR DESCRIPTION
- Updated function signatures from `void *priv` to `unsigned long priv`
- Added `__noreturn` to `thread_exit()` because of `CONFIG_OBJTOOL_WERROR` enforcement

Should fixes #135 