### PR TITLE
RTL8189ES: fix compile on Linux 7.2

### DIFF
--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -634,7 +634,11 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				char tmp_str[10] = {'\0'};
 
 				len = snprintf(tmp_str, sizeof(tmp_str), "%s", "ap_id:");
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(p, len, tmp_str, len, '\0');
+#else
 				strncpy(p, tmp_str, len);
+#endif
 				p += len;
 				_rtw_memset(&tmp_str, '\0', sizeof(tmp_str));
 				#ifdef DBG_HW_PORT
@@ -642,7 +646,11 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				#else
 				len = snprintf(tmp_str, sizeof(tmp_str), "%d", iface->vap_id);
 				#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(p, len, tmp_str, len, '\0');
+#else
 				strncpy(p, tmp_str, len);
+#endif
 			}
 			#endif
 			#ifdef CONFIG_CLIENT_PORT_CFG
@@ -652,7 +660,11 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				char tmp_str[10] = {'\0'};
 
 				len = snprintf(tmp_str, sizeof(tmp_str), "%s", "c_pid:");
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(p, len, tmp_str, len, '\0');
+#else
 				strncpy(p, tmp_str, len);
+#endif
 				p += len;
 				_rtw_memset(&tmp_str, '\0', sizeof(tmp_str));
 				#ifdef DBG_HW_PORT
@@ -660,7 +672,11 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				#else
 				len = snprintf(tmp_str, sizeof(tmp_str), "%d", iface->client_port);
 				#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(p, len, tmp_str, len, '\0');
+#else
 				strncpy(p, tmp_str, len);
+#endif
 			}
 			#endif
 
@@ -7227,11 +7243,19 @@ inline void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 		if (_titlestring) {
 			if (sel == RTW_DBGDUMP) {
 				len = snprintf(str_val, sizeof(str_val), "%s", DRIVER_PREFIX);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(p, len, str_val, len, '\0');
+#else
 				strncpy(p, str_val, len);
+#endif
 				p += len;
 			}
 			len = snprintf(str_val, sizeof(str_val), "%s", _titlestring);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+			memcpy_and_pad(p, len, str_val, len, '\0');
+#else
 			strncpy(p, str_val, len);
+#endif
 			p += len;
 		}
 		if (p != &str_out[0]) {
@@ -7246,18 +7270,30 @@ inline void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 			p = &str_out[0];
 			if (sel == RTW_DBGDUMP) {
 				len = snprintf(str_val, sizeof(str_val), "%s", DRIVER_PREFIX);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(p, len, str_val, len, '\0');
+#else
 				strncpy(p, str_val, len);
+#endif
 				p += len;
 			}
 			if (_idx_show) {
 				len = snprintf(str_val, sizeof(str_val), "0x%03X: ", __i * RTW_BUFDUMP_BSIZE);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(p, len, str_val, len, '\0');
+#else
 				strncpy(p, str_val, len);
+#endif
 				p += len;
 			}
 			for (__j =0; __j < RTW_BUFDUMP_BSIZE; __j++) {
 				idx = __i * RTW_BUFDUMP_BSIZE + __j;
 				len = snprintf(str_val, sizeof(str_val), "%02X%s", ptr[idx], (((__j + 1) % 4) == 0) ? "  " : " ");
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(p, len, str_val, len, '\0');
+#else
 				strncpy(p, str_val, len);
+#endif
 				p += len;
 			}
 			_RTW_STR_DUMP_SEL(sel, str_out);
@@ -7267,18 +7303,30 @@ inline void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 		p = &str_out[0];
 		if ((sel == RTW_DBGDUMP) && remain_byte) {
 			len = snprintf(str_val, sizeof(str_val), "%s", DRIVER_PREFIX);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+			memcpy_and_pad(p, len, str_val, len, '\0');
+#else
 			strncpy(p, str_val, len);
+#endif
 			p += len;
 		}
 		if (_idx_show && remain_byte) {
 			len = snprintf(str_val, sizeof(str_val), "0x%03X: ", block_num * RTW_BUFDUMP_BSIZE);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+			memcpy_and_pad(p, len, str_val, len, '\0');
+#else
 			strncpy(p, str_val, len);
+#endif
 			p += len;
 		}
 		for (__i = 0; __i < remain_byte; __i++) {
 			idx = block_num * RTW_BUFDUMP_BSIZE + __i;
 			len = snprintf(str_val, sizeof(str_val), "%02X%s", ptr[idx], (((__i + 1) % 4) == 0) ? "  " : " ");
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+			memcpy_and_pad(p, len, str_val, len, '\0');
+#else
 			strncpy(p, str_val, len);
+#endif
 			p += len;
 		}
 		_RTW_STR_DUMP_SEL(sel, str_out);

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -13149,7 +13149,11 @@ ParseQualifiedString(
 		return _FALSE;
 
 	j = (*Start) - 2;
-	strncpy((char *)Out, (const char *)(In + i), j - i + 1);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	memcpy_and_pad(Out, j - i + 1, In + i, j - i + 1, '\0');
+#else
+	strncpy(Out, In + i, j - i + 1);
+#endif
 
 	return _TRUE;
 }

--- a/hal/hal_com_phycfg.c
+++ b/hal/hal_com_phycfg.c
@@ -5086,9 +5086,15 @@ PHY_ConfigRFWithTxPwrTrackParaFile(
 				if (strlen(szLine) < 10 || szLine[0] != '[')
 					continue;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(band, sizeof(band), szLine + 1, 2, '\0');
+				memcpy_and_pad(path, sizeof(path), szLine + 5, 1, '\0');
+				memcpy_and_pad(sign, sizeof(sign), szLine + 8, 1, '\0');
+#else
 				strncpy(band, szLine + 1, 2);
 				strncpy(path, szLine + 5, 1);
 				strncpy(sign, szLine + 8, 1);
+#endif
 
 				i = 10; /* szLine+10 */
 				if (!ParseQualifiedString(szLine, &i, rate, '[', ']')) {

--- a/hal/hal_hci/hal_sdio.c
+++ b/hal/hal_hci/hal_sdio.c
@@ -37,13 +37,21 @@ static void dump_mac_page0(PADAPTER padapter)
 		p = &str_out[0];
 		len = snprintf(str_val, sizeof(str_val),
 			       "0x%02x: ", index);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+		memcpy_and_pad(str_out, len, str_val, len, '\0');
+#else
 		strncpy(str_out, str_val, len);
+#endif
 		p += len;
 
 		for (i = 0 ; i < 16 ; i++) {
 			len = snprintf(str_val, sizeof(str_val), "%02x ",
 				       rtw_read8(padapter, index + i));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+			memcpy_and_pad(p, len, str_val, len, '\0');
+#else
 			strncpy(p, str_val, len);
+#endif
 			p += len;
 		}
 		RTW_INFO("%s\n", str_out);

--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -5558,8 +5558,13 @@ void phydm_fw_trace_handler(void *dm_void, u8 *cmd_buf, u8 cmd_len)
 		return;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	memcpy_and_pad(&dm->fw_debug_trace[dm->c2h_cmd_start], (cmd_len - 1),
+		       &cmd_buf[1], (cmd_len - 1), '\0');
+#else
 	strncpy((char *)&dm->fw_debug_trace[dm->c2h_cmd_start],
 		(char *)&cmd_buf[1], (cmd_len - 1));
+#endif
 	dm->c2h_cmd_start += (cmd_len - 1);
 	dm->fw_buff_is_enpty = false;
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1773,7 +1773,11 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy,
 		goto addkey_end;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy_pad((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+#else
 	strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+#endif
 
 
 	if (!mac_addr || is_broadcast_ether_addr(mac_addr)
@@ -4792,7 +4796,11 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	}
 
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy_pad(mon_ndev->name, name, IFNAMSIZ);
+#else
 	strncpy(mon_ndev->name, name, IFNAMSIZ);
+#endif
 	mon_ndev->name[IFNAMSIZ - 1] = 0;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4, 11, 8))
 	mon_ndev->priv_destructor = rtw_ndev_destructor;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -6873,7 +6873,11 @@ static s32 cfg80211_rtw_remain_on_channel(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0))
 	enum nl80211_channel_type channel_type,
 #endif
-	unsigned int duration, u64 *cookie)
+	unsigned int duration, u64 *cookie
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	, const u8 *rx_addr
+#endif
+	)
 {
 	s32 err = 0;
 	u8 remain_ch = (u8) ieee80211_frequency_to_channel(channel->center_freq);

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -3141,7 +3141,11 @@ static int rtw_wx_set_enc_ext(struct net_device *dev,
 		goto exit;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy_pad((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+#else
 	strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+#endif
 
 	if (pext->ext_flags & IW_ENCODE_EXT_SET_TX_KEY)
 		param->u.crypt.set_tx = 1;
@@ -5769,7 +5773,11 @@ static int rtw_rereg_nd_name(struct net_device *dev,
 #endif
 			reg_ifname = padapter->registrypriv.if2name;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+		strscpy_pad(rereg_priv->old_ifname, reg_ifname, IFNAMSIZ);
+#else
 		strncpy(rereg_priv->old_ifname, reg_ifname, IFNAMSIZ);
+#endif
 		rereg_priv->old_ifname[IFNAMSIZ - 1] = 0;
 	}
 
@@ -5794,7 +5802,11 @@ static int rtw_rereg_nd_name(struct net_device *dev,
 		/* rtw_ips_mode_req(&padapter->pwrctrlpriv, rereg_priv->old_ips_mode); */
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy_pad(rereg_priv->old_ifname, new_ifname, IFNAMSIZ);
+#else
 	strncpy(rereg_priv->old_ifname, new_ifname, IFNAMSIZ);
+#endif
 	rereg_priv->old_ifname[IFNAMSIZ - 1] = 0;
 
 	if (_rtw_memcmp(new_ifname, "disable%d", 9) == _TRUE) {

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1682,7 +1682,11 @@ static int rtw_ndev_init(struct net_device *dev)
 
 	RTW_PRINT(FUNC_ADPT_FMT" if%d mac_addr="MAC_FMT"\n"
 		, FUNC_ADPT_ARG(adapter), (adapter->iface_id + 1), MAC_ARG(dev->dev_addr));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy_pad(adapter->old_ifname, dev->name, IFNAMSIZ);
+#else
 	strncpy(adapter->old_ifname, dev->name, IFNAMSIZ);
+#endif
 	adapter->old_ifname[IFNAMSIZ - 1] = '\0';
 	rtw_adapter_proc_init(dev);
 

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -1379,8 +1379,12 @@ static int rtw_cfgvendor_logger_start_logging(struct wiphy *wiphy,
 		type = nla_type(iter);
 		switch (type) {
 			case LOGGER_ATTRIBUTE_RING_NAME:
-				strncpy(ring_name, nla_data(iter),
-					MIN(sizeof(ring_name) -1, nla_len(iter)));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(ring_name, sizeof(ring_name), nla_data(iter),
+					MIN(sizeof(ring_name) - 1, nla_len(iter)), '\0');
+#else
+				strncpy(ring_name, nla_data(iter), MIN(sizeof(ring_name) - 1, nla_len(iter)));
+#endif
 				break;
 			case LOGGER_ATTRIBUTE_LOG_LEVEL:
 				log_level = nla_get_u32(iter);
@@ -1508,8 +1512,12 @@ static int rtw_cfgvendor_logger_get_ring_data(struct wiphy *wiphy,
 		type = nla_type(iter);
 		switch (type) {
 			case LOGGER_ATTRIBUTE_RING_NAME:
-				strncpy(ring_name, nla_data(iter),
-					MIN(sizeof(ring_name) -1, nla_len(iter)));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				memcpy_and_pad(ring_name, sizeof(ring_name), nla_data(iter),
+					MIN(sizeof(ring_name) - 1, nla_len(iter)), '\0');
+#else
+				strncpy(ring_name, nla_data(iter), MIN(sizeof(ring_name) - 1, nla_len(iter)));
+#endif
 				RTW_INFO(" %s LOGGER_ATTRIBUTE_RING_NAME : %s\n", __func__, ring_name);
 				break;
 			default:


### PR DESCRIPTION
This resolves two sources of compile failures on Linux 7.2 which notably removed strncpy() from the kernel.

Changes are compile tested only as I don't have RTL8189ES hardware.